### PR TITLE
Unify top-bar button height to 40px

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -548,10 +548,11 @@ footer a:hover{ color: var(--accent); }
     padding: 0;
     margin: 0 calc(-1 * var(--gutter));
     background: var(--bg);
-    border-top: 1px solid var(--rule);
   }
+  /* Top border only when expanded — otherwise it doubles up with .nav's border-bottom. */
   .nav-toggle:checked ~ ul{
     max-height: 480px;
+    border-top: 1px solid var(--rule);
   }
   .nav ul li{ border-bottom: 1px solid var(--rule); }
   .nav ul li:last-child{ border-bottom: 0; }

--- a/styles.css
+++ b/styles.css
@@ -83,7 +83,8 @@ img{ max-width:100%; display:block; }
 .nav-actions{ display: flex; align-items: center; gap: 10px; }
 .nav-cta{
   display: inline-flex; align-items: center; gap: 12px;
-  padding: 14px 22px;
+  height: 40px;
+  padding: 0 22px;
   background: var(--accent); color: #fff;
   border: 1px solid var(--accent);
   text-decoration: none;
@@ -112,7 +113,7 @@ img{ max-width:100%; display:block; }
 /* ── Theme toggle (sun/moon) ─────────────────── */
 .theme-toggle{
   display: inline-flex; align-items: center; justify-content: center;
-  width: 38px; height: 38px;
+  width: 40px; height: 40px;
   border: 1px solid var(--rule-2);
   background: transparent;
   color: var(--ink-2);
@@ -565,7 +566,7 @@ footer a:hover{ color: var(--accent); }
 
   .nav-cta{
     order: 3;
-    padding: 10px 14px;
+    padding: 0 14px;
     font-size: 12.5px;
   }
 


### PR DESCRIPTION
## Summary

The three top-bar elements were all different heights:
- theme toggle: **38×38**
- ozvěte se CTA: padding-driven, computed to **~46px** desktop / ~36px mobile
- hamburger: **40×40** (mobile only)

Now all three lock to **40px** on every viewport — desktop and mobile.

## Changes

- `.theme-toggle` → 40×40 (was 38)
- `.nav-cta` → explicit `height: 40px`, padding becomes horizontal-only (`0 22px` desktop, `0 14px` mobile). Flex centers the label + arrow vertically.
- `.nav-burger` already 40px; unchanged.

## Test plan

- [ ] Open preview, eyeball the desktop nav — sun/moon, "ozvěte se", and the line under the page are flush
- [ ] Shrink to <900px, open the menu — hamburger and CTA sit at matching height
- [ ] CTA hover still flips colors and slides the arrow