### PR TITLE
Fix deploy workflow: split prod/PR concurrency lanes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,13 +3,25 @@ name: Deploy
 on:
   push:
     branches: [master]
+    # Skip when only non-site files change.
+    paths-ignore:
+      - 'README.md'
+      - '.claude/**'
   pull_request:
     types: [opened, reopened, synchronize, closed]
+    paths-ignore:
+      - 'README.md'
+      - '.claude/**'
 
-# Prevent concurrent deploys racing on the same ref.
+# Two distinct concurrency lanes so prod and PR events never cancel each other:
+# - Production (push to master): queue, never cancel — every commit must deploy.
+# - PR previews: cancel-in-progress so a fast-follow commit supersedes the old build.
 concurrency:
-  group: pages-${{ github.ref }}
-  cancel-in-progress: true
+  group: >-
+    ${{ github.event_name == 'pull_request'
+        && format('pages-pr-{0}', github.event.number)
+        || 'pages-prod' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   deploy:


### PR DESCRIPTION
## The bug

PR #9 (SEO) was merged at 09:49:31 UTC. The push-to-master deploy run ([26218631670](https://github.com/janfabian/terezafabianova.cz/actions/runs/26218631670)) was cancelled **2 seconds later, before any step executed**. Result: `f11c9bf` sat on master with no corresponding gh-pages update — sitemap.xml + meta tags simply weren't live.

I re-ran the cancelled run manually so production is now correct, but the underlying race will hit again on the next merge.

## Root cause

`gh pr merge` fires both `push` and `pull_request closed` events back-to-back. The previous concurrency setup —

```yaml
group: pages-${{ github.ref }}
cancel-in-progress: true
```

— is meant to give the two events different groups (`refs/heads/master` vs `refs/pull/N/merge`), but in practice the back-to-back queuing window let one cancel the other. `cancel-in-progress` is the wrong policy for production: a master deploy must never be skipped.

## Fix

Two explicit lanes:

| Event | Group | cancel-in-progress |
|---|---|---|
| Push to master | `pages-prod` | **false** — queue, never skip |
| PR open/sync/close | `pages-pr-<n>` | **true** — fast-follow commit supersedes |

Different group strings → can't cancel each other. Production keeps queueing so every commit deploys. PRs still skip stale builds when you push quickly.

Also added `paths-ignore` for `README.md` and `.claude/**` so cosmetic changes don't spin up CI.

## Test plan

- [ ] Merge this PR → push-to-master deploy run executes, `pages-prod` group shows in run logs
- [ ] Next PR opened → preview deploys to `/pr-preview/pr-<n>/`
- [ ] Push two commits fast onto a PR → first preview build cancels, only second deploys
- [ ] Merge a PR → both the push run and the PR-close cleanup complete (neither cancels the other)